### PR TITLE
Update with correct links to vercel docs

### DIFF
--- a/docs/pages/docs/guides/frameworks/nextjs-app.mdx
+++ b/docs/pages/docs/guides/frameworks/nextjs-app.mdx
@@ -20,7 +20,7 @@ import OpenAI from 'openai'
 import { OpenAIStream, StreamingTextResponse } from 'ai'
 
 // Optional, but recommended: run on the edge runtime.
-// See https://vercel.com/docs/concepts/functions/edge-functions
+// See https://vercel.com/docs/infrastructure/runtime-comparison#edge
 export const runtime = 'edge'
 
 const openai = new OpenAI({
@@ -46,7 +46,7 @@ export async function POST(req: Request) {
 }
 ```
 
-Note that using the Edge Runtime is optional but highly recommended due to [longer streaming timeouts on Vercel](https://vercel.com/docs/concepts/functions/edge-functions/limitations#maximum-initial-response-time), no cold starts, and lower latency.
+Note that using the Edge Runtime is optional but highly recommended due to [longer streaming timeouts on Vercel](https://vercel.com/docs/functions/edge-functions/limitations#maximum-initial-response-time), no cold starts, and lower latency.
 
 ## In Server Components
 
@@ -59,7 +59,7 @@ import { OpenAIStream } from 'ai'
 import { Suspense } from 'react'
 
 // Optional, but recommended: run on the edge runtime.
-// See https://vercel.com/docs/concepts/functions/edge-functions
+// See https://vercel.com/docs/infrastructure/runtime-comparison#edge
 export const runtime = 'edge'
 
 const openai = new OpenAI({


### PR DESCRIPTION
This PR updates links in the next-app example to point to the correct docs on vercel docs site